### PR TITLE
docs: mention Zoo Code as the Roo Code community successor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run **local LLM models on Google Colab** and access them remotely via API — id
 
 - 🔥 Run advanced LLMs (like Qwen, LLaMA3, Mistral, DeepSeek) in Colab using [Ollama](https://ollama.com/)
 - 🌐 Expose the model via secure public URL using `cloudflared`
-- 🧑‍💻 Integrate with [ROO Code](https://roo.dev) in VS Code for seamless coding assistance
+- 🧑‍💻 Integrate with [ROO Code](https://roo.dev) or its community successor [Zoo Code](https://zoocode.dev/) in VS Code for seamless coding assistance
 - ✅ Automatically detects and waits for Ollama to be ready before tunneling
 - 💡 Simple, professional, and reusable setup
 


### PR DESCRIPTION
Roo Code (`RooCodeInc/Roo-Code`) was archived / shut down on May 15, 2026 and is now
read-only. Its own repo notes the community successor here:
https://github.com/RooCodeInc/Roo-Code#disclaimer

Zoo Code is the community-maintained fork that continues where Roo Code left off:
- Site: https://zoocode.dev/
- Source: https://github.com/Zoo-Code-Org/Zoo-Code/

This PR adds a Zoo Code reference alongside the existing Roo Code mention in the README so
readers looking for a maintained alternative can find it.
